### PR TITLE
FEAT: 여러 카트를 가질 수 있도록 추가 및 region을 lDong 관련으로 바꾸도록 변경

### DIFF
--- a/Back-end/src/main/java/com/example/backend/cart/controller/CartController.java
+++ b/Back-end/src/main/java/com/example/backend/cart/controller/CartController.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -206,5 +207,77 @@ public class CartController {
         }
         
         return request.getRemoteAddr();
+    }
+
+    @PostMapping("/carts")
+    @Operation(summary = "새 장바구니 생성", description = "사용자의 새 장바구니 생성",
+            security = @SecurityRequirement(name = "JWT"))
+    public ResponseEntity<CartResponse.CartDetailResponse> createCart(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Parameter(description = "법정동 시/도 코드", example = "11")
+            @RequestParam(value = "lDongRegnCd", defaultValue = "11") String lDongRegnCd,
+            @Parameter(description = "법정동 시 코드", example = "110")
+            @RequestParam(value = "lDongSignguCd", defaultValue = "110") String lDongSignguCd) {
+        CartResponse.CartDetailResponse response = cartService.createCart(userDetails.getUsername(), lDongRegnCd, lDongSignguCd);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/carts")
+    @Operation(summary = "사용자의 모든 장바구니 조회", description = "사용자의 모든 장바구니 목록 조회",
+            security = @SecurityRequirement(name = "JWT"))
+    public ResponseEntity<List<CartResponse.CartDetailResponse>> getUserCarts(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        List<CartResponse.CartDetailResponse> response = cartService.getUserCarts(userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/carts/{cartId}")
+    @Operation(summary = "특정 장바구니 조회", description = "cartId로 특정 장바구니 조회",
+            security = @SecurityRequirement(name = "JWT"))
+    public ResponseEntity<CartResponse.CartDetailResponse> getCartById(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Parameter(description = "장바구니 ID")
+            @PathVariable UUID cartId) {
+        CartResponse.CartDetailResponse response = cartService.getCartById(userDetails.getUsername(), cartId);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/carts/{cartId}")
+    @Operation(summary = "장바구니 삭제", description = "특정 장바구니와 그 안의 모든 투어 삭제",
+            security = @SecurityRequirement(name = "JWT"))
+    public ResponseEntity<Void> deleteCart(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Parameter(description = "장바구니 ID")
+            @PathVariable UUID cartId) {
+        cartService.deleteCart(userDetails.getUsername(), cartId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/carts/{cartId}/tours")
+    @Operation(summary = "특정 장바구니에 투어 추가", description = "지정된 장바구니에 새로운 투어 추가",
+            security = @SecurityRequirement(name = "JWT"))
+    public ResponseEntity<CartResponse.AddTourResponse> addTourToSpecificCart(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Parameter(description = "장바구니 ID")
+            @PathVariable UUID cartId,
+            @RequestBody CartResponse.TourSearchResponse tourResponse) {
+        CartResponse.AddTourResponse response = cartService.addTourToSpecificCart(userDetails.getUsername(), cartId, tourResponse);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/carts/{cartId}/tours/simple")
+    @Operation(summary = "특정 장바구니에 투어 추가 (contentId만)", 
+               description = "지정된 장바구니에 contentId로 투어 추가",
+               security = @SecurityRequirement(name = "JWT"))
+    public ResponseEntity<CartResponse.AddTourResponse> addTourToSpecificCartByContentId(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Parameter(description = "장바구니 ID")
+            @PathVariable UUID cartId,
+            @Parameter(description = "추가할 투어의 contentId", example = "126508")
+            @RequestParam("contentId") String contentId) {
+        
+        CartResponse.AddTourResponse response = cartService.addTourToSpecificCartByContentId(
+                userDetails.getUsername(), cartId, contentId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/Back-end/src/main/java/com/example/backend/cart/dto/response/CartResponse.java
+++ b/Back-end/src/main/java/com/example/backend/cart/dto/response/CartResponse.java
@@ -12,7 +12,8 @@ public class CartResponse {
     @AllArgsConstructor
     public static class CartDetailResponse {
         private UUID cartId;
-        private String region;
+        private String lDongRegnCd;
+        private String lDongSignguCd;
         private java.util.List<TourInfo> tours;
         private int totalCount;
         private long totalPrice;

--- a/Back-end/src/main/java/com/example/backend/cart/entity/Cart.java
+++ b/Back-end/src/main/java/com/example/backend/cart/entity/Cart.java
@@ -21,11 +21,14 @@ public class Cart {
     @Column(name = "cart_id", columnDefinition = "BINARY(16)", nullable = false)
     private UUID cartId;
 
-    @Column(name = "region", length = 255, nullable = false)
-    private String region;
+    @Column(name = "l_dong_regn_cd", length = 10, nullable = false)
+    private String lDongRegnCd;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @Column(name = "l_dong_signgu_cd", length = 10, nullable = false)
+    private String lDongSignguCd;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = false)
     private User userId;
 
     @Column(name = "budget")

--- a/Back-end/src/main/java/com/example/backend/cart/repository/CartRepository.java
+++ b/Back-end/src/main/java/com/example/backend/cart/repository/CartRepository.java
@@ -5,6 +5,7 @@ import com.example.backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -14,4 +15,8 @@ public interface CartRepository extends JpaRepository<Cart, UUID> {
     Optional<Cart> findByUserId(User user);
 
     boolean existsByUserId(User user);
+
+    List<Cart> findAllByUserId(User user);
+
+    Optional<Cart> findByCartIdAndUserId(UUID cartId, User user);
 }

--- a/Back-end/src/main/java/com/example/backend/cart/service/CartService.java
+++ b/Back-end/src/main/java/com/example/backend/cart/service/CartService.java
@@ -81,7 +81,7 @@ public class CartService {
                 .totalCount(tourInfos.size())
                 .totalPrice(totalPrice)
                 .build();
-    }
+    } 
 
     @Transactional
     public CartResponse.AddTourResponse addTourToCart(String userIdString, CartResponse.TourSearchResponse tourResponse) {

--- a/Back-end/src/main/java/com/example/backend/cart/service/CartService.java
+++ b/Back-end/src/main/java/com/example/backend/cart/service/CartService.java
@@ -542,4 +542,9 @@ public class CartService {
                 .message("투어가 장바구니에 추가되었습니다.")
                 .build();
     }
+    @Transactional(readOnly = true)
+    public Cart findCartById(UUID cartId) {
+        return cartRepository.findById(cartId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 장바구니입니다. cartId: " + cartId));
+    }
 }

--- a/Back-end/src/main/java/com/example/backend/cart/service/CartService.java
+++ b/Back-end/src/main/java/com/example/backend/cart/service/CartService.java
@@ -44,7 +44,8 @@ public class CartService {
         if (cart == null) {
             return CartResponse.CartDetailResponse.builder()
                     .cartId(null)
-                    .region("서울")
+                    .lDongRegnCd("11")
+                    .lDongSignguCd("110")
                     .tours(List.of())
                     .totalCount(0)
                     .totalPrice(0L)
@@ -74,7 +75,8 @@ public class CartService {
 
         return CartResponse.CartDetailResponse.builder()
                 .cartId(cart.getCartId())
-                .region(cart.getRegion())
+                .lDongRegnCd(cart.getLDongRegnCd())
+                .lDongSignguCd(cart.getLDongSignguCd())
                 .tours(tourInfos)
                 .totalCount(tourInfos.size())
                 .totalPrice(totalPrice)
@@ -133,11 +135,11 @@ public class CartService {
 
         Tour savedTour = tourRepository.save(tour);
 
-        if (cart.getRegion() == null || cart.getRegion().isEmpty()) {
-            String region = extractRegionFromAddress(tourResponse.getAddress());
+        if (cart.getLDongRegnCd() == null || cart.getLDongRegnCd().isEmpty()) {
             cart = Cart.builder()
                     .cartId(cart.getCartId())
-                    .region(region)
+                    .lDongRegnCd("11")
+                    .lDongSignguCd("110")
                     .userId(cart.getUserId())
                     .build();
             cartRepository.save(cart);
@@ -292,11 +294,11 @@ public class CartService {
 
         Tour savedTour = tourRepository.save(tour);
 
-        if (cart.getRegion() == null || cart.getRegion().isEmpty()) {
-            String region = tourDetail.getRegion();
+        if (cart.getLDongRegnCd() == null || cart.getLDongRegnCd().isEmpty()) {
             cart = Cart.builder()
                     .cartId(cart.getCartId())
-                    .region(region != null ? region : "기타")
+                    .lDongRegnCd("11")
+                    .lDongSignguCd("110")
                     .userId(cart.getUserId())
                     .build();
             cartRepository.save(cart);
@@ -311,7 +313,8 @@ public class CartService {
     private Cart createNewCart(User user) {
         Cart cart = Cart.builder()
                 .userId(user)
-                .region("서울")
+                .lDongRegnCd("11")
+                .lDongSignguCd("110")
                 .build();
         return cartRepository.save(cart);
     }
@@ -322,5 +325,221 @@ public class CartService {
             return parts[0];
         }
         return "기타";
+    }
+
+    @Transactional
+    public CartResponse.CartDetailResponse createCart(String userIdString, String lDongRegnCd, String lDongSignguCd) {
+        UUID userId = UUID.fromString(userIdString);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Cart cart = Cart.builder()
+                .userId(user)
+                .lDongRegnCd(lDongRegnCd != null ? lDongRegnCd : "11")
+                .lDongSignguCd(lDongSignguCd != null ? lDongSignguCd : "110")
+                .build();
+        Cart savedCart = cartRepository.save(cart);
+
+        return CartResponse.CartDetailResponse.builder()
+                .cartId(savedCart.getCartId())
+                .lDongRegnCd(savedCart.getLDongRegnCd())
+                .lDongSignguCd(savedCart.getLDongSignguCd())
+                .tours(List.of())
+                .totalCount(0)
+                .totalPrice(0L)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CartResponse.CartDetailResponse> getUserCarts(String userIdString) {
+        UUID userId = UUID.fromString(userIdString);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        List<Cart> carts = cartRepository.findAllByUserId(user);
+
+        return carts.stream()
+                .map(cart -> {
+                    List<Tour> tours = tourRepository.findByCartId(cart);
+                    
+                    List<CartResponse.TourInfo> tourInfos = tours.stream()
+                            .map(tour -> CartResponse.TourInfo.builder()
+                                    .tourId(tour.getTourId())
+                                    .contentId(tour.getContentId())
+                                    .title(tour.getTitle())
+                                    .image(tour.getImage())
+                                    .tema(tour.getTema())
+                                    .longitude(tour.getLongitude())
+                                    .latitude(tour.getLatitude())
+                                    .address(tour.getAddress())
+                                    .category(tour.getCategory())
+                                    .price(tour.getPrice())
+                                    .build())
+                            .collect(Collectors.toList());
+
+                    long totalPrice = tourInfos.stream()
+                            .mapToLong(t -> t.getPrice() != null ? t.getPrice() : 0)
+                            .sum();
+
+                    return CartResponse.CartDetailResponse.builder()
+                            .cartId(cart.getCartId())
+                            .lDongRegnCd(cart.getLDongRegnCd())
+                .lDongSignguCd(cart.getLDongSignguCd())
+                            .tours(tourInfos)
+                            .totalCount(tourInfos.size())
+                            .totalPrice(totalPrice)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public CartResponse.CartDetailResponse getCartById(String userIdString, UUID cartId) {
+        UUID userId = UUID.fromString(userIdString);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Cart cart = cartRepository.findByCartIdAndUserId(cartId, user)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니를 찾을 수 없습니다."));
+
+        List<Tour> tours = tourRepository.findByCartId(cart);
+
+        List<CartResponse.TourInfo> tourInfos = tours.stream()
+                .map(tour -> CartResponse.TourInfo.builder()
+                        .tourId(tour.getTourId())
+                        .contentId(tour.getContentId())
+                        .title(tour.getTitle())
+                        .image(tour.getImage())
+                        .tema(tour.getTema())
+                        .longitude(tour.getLongitude())
+                        .latitude(tour.getLatitude())
+                        .address(tour.getAddress())
+                        .category(tour.getCategory())
+                        .price(tour.getPrice())
+                        .build())
+                .collect(Collectors.toList());
+
+        long totalPrice = tourInfos.stream()
+                .mapToLong(t -> t.getPrice() != null ? t.getPrice() : 0)
+                .sum();
+
+        return CartResponse.CartDetailResponse.builder()
+                .cartId(cart.getCartId())
+                .lDongRegnCd(cart.getLDongRegnCd())
+                .lDongSignguCd(cart.getLDongSignguCd())
+                .tours(tourInfos)
+                .totalCount(tourInfos.size())
+                .totalPrice(totalPrice)
+                .build();
+    }
+
+    @Transactional
+    public void deleteCart(String userIdString, UUID cartId) {
+        UUID userId = UUID.fromString(userIdString);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Cart cart = cartRepository.findByCartIdAndUserId(cartId, user)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니를 찾을 수 없습니다."));
+
+        tourRepository.deleteAllByCartId(cart);
+        cartRepository.delete(cart);
+        log.info("장바구니 삭제 완료 - cartId: {}", cartId);
+    }
+
+    @Transactional
+    public CartResponse.AddTourResponse addTourToSpecificCart(String userIdString, UUID cartId, CartResponse.TourSearchResponse tourResponse) {
+        UUID userId = UUID.fromString(userIdString);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Cart cart = cartRepository.findByCartIdAndUserId(cartId, user)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니를 찾을 수 없습니다."));
+
+        boolean isDuplicate = tourRepository.existsByCartIdAndAddress(cart, tourResponse.getAddress());
+        if (isDuplicate) {
+            throw new IllegalArgumentException("이미 장바구니에 추가된 투어입니다.");
+        }
+
+        Tour tour = Tour.builder()
+                .contentId(tourResponse.getContentId())
+                .contentTypeId(tourResponse.getContentTypeId())
+                .title(tourResponse.getTitle())
+                .address(tourResponse.getAddress())
+                .address2(tourResponse.getAddress2())
+                .zipcode(tourResponse.getZipcode())
+                .areaCode(tourResponse.getAreaCode())
+                .cat1(tourResponse.getCat1())
+                .cat2(tourResponse.getCat2())
+                .cat3(tourResponse.getCat3())
+                .createdTime(tourResponse.getCreatedTime())
+                .firstImage(tourResponse.getFirstImage())
+                .firstImage2(tourResponse.getFirstImage2())
+                .cpyrhtDivCd(tourResponse.getCpyrhtDivCd())
+                .mapX(tourResponse.getMapX())
+                .mapY(tourResponse.getMapY())
+                .mlevel(tourResponse.getMlevel())
+                .modifiedTime(tourResponse.getModifiedTime())
+                .sigunguCode(tourResponse.getSigunguCode())
+                .tel(tourResponse.getTel())
+                .overview("")
+                .lDongRegnCd(tourResponse.getLDongRegnCd())
+                .lDongSignguCd(tourResponse.getLDongSignguCd())
+                .lclsSystm1(tourResponse.getLclsSystm1())
+                .lclsSystm2(tourResponse.getLclsSystm2())
+                .lclsSystm3(tourResponse.getLclsSystm3())
+                .longitude(tourResponse.getMapX() != null && !tourResponse.getMapX().isEmpty()
+                        ? Double.valueOf(tourResponse.getMapX()) : null)
+                .latitude(tourResponse.getMapY() != null && !tourResponse.getMapY().isEmpty()
+                        ? Double.valueOf(tourResponse.getMapY()) : null)
+                .image(tourResponse.getFirstImage())
+                .tema("")
+                .cartId(cart)
+                .build();
+
+        Tour savedTour = tourRepository.save(tour);
+
+        return CartResponse.AddTourResponse.builder()
+                .tourId(savedTour.getTourId())
+                .message("투어가 장바구니에 추가되었습니다.")
+                .build();
+    }
+
+    @Transactional
+    public CartResponse.AddTourResponse addTourToSpecificCartByContentId(String userIdString, UUID cartId, String contentId) {
+        UUID userId = UUID.fromString(userIdString);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Cart cart = cartRepository.findByCartIdAndUserId(cartId, user)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니를 찾을 수 없습니다."));
+
+        boolean isDuplicate = tourRepository.existsByCartIdAndContentId(cart, contentId);
+        if (isDuplicate) {
+            throw new IllegalArgumentException("이미 장바구니에 추가된 투어입니다.");
+        }
+
+        CartResponse.TourDetailResponse tourDetail = tourApiClient.getTourDetail(contentId);
+
+        Tour tour = Tour.builder()
+                .contentId(contentId)
+                .contentTypeId(tourDetail.getContentTypeId())
+                .title(tourDetail.getTitle())
+                .address(tourDetail.getAddress())
+                .longitude(tourDetail.getLongitude())
+                .latitude(tourDetail.getLatitude())
+                .image(tourDetail.getImage())
+                .tel(tourDetail.getTel())
+                .overview(tourDetail.getOverview())
+                .tema(tourDetail.getTheme())
+                .cartId(cart)
+                .build();
+
+        Tour savedTour = tourRepository.save(tour);
+
+        return CartResponse.AddTourResponse.builder()
+                .tourId(savedTour.getTourId())
+                .message("투어가 장바구니에 추가되었습니다.")
+                .build();
     }
 }

--- a/Back-end/src/main/java/com/example/backend/scheduleItem/entity/ScheduleItem.java
+++ b/Back-end/src/main/java/com/example/backend/scheduleItem/entity/ScheduleItem.java
@@ -39,7 +39,7 @@ public class ScheduleItem {
     @Column(name = "cost", nullable = false)
     private int cost;
 
-    @Column(name = "order", nullable = true)
+    @Column(name = "`order`", nullable = true)
     private int order;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/Back-end/src/main/java/com/example/backend/scheduleItem/entity/ScheduleItem.java
+++ b/Back-end/src/main/java/com/example/backend/scheduleItem/entity/ScheduleItem.java
@@ -39,7 +39,7 @@ public class ScheduleItem {
     @Column(name = "cost", nullable = false)
     private int cost;
 
-    @Column(name = "`order`", nullable = true)
+    @Column(name = "\"order\"", nullable = true)
     private int order;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/Back-end/src/main/java/com/example/backend/user/entity/User.java
+++ b/Back-end/src/main/java/com/example/backend/user/entity/User.java
@@ -1,9 +1,11 @@
 package com.example.backend.user.entity;
+import com.example.backend.cart.entity.Cart;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -45,6 +47,9 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(name = "user_role", length = 20, nullable = false)
     private Role userRole = Role.USER;  // 기본값 USER로 설정
+
+    @OneToMany(mappedBy = "userId")
+    private List<Cart> carts;
 
     public enum Role {
         USER,


### PR DESCRIPTION
## 개요
  - 유저-카트 관계를 일대일에서 일대다로 변경하여 사용자가 여러 개의 장바구니를 가질 수 있도록 구현
  - 기존 region 필드를 법정동 코드(lDongRegnCd, lDongSignguCd)로 분리하여 다른 API들과 일관성 유지
  - 여러 카트 관리를 위한 새로운 REST API 엔드포인트 추가

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
