### PR TITLE
FEAT: 사용자 탈퇴 로직 구현

### DIFF
--- a/Back-end/src/main/java/com/example/backend/board/repository/BoardRepository.java
+++ b/Back-end/src/main/java/com/example/backend/board/repository/BoardRepository.java
@@ -1,6 +1,7 @@
 package com.example.backend.board.repository;
 
 import com.example.backend.board.entity.Board;
+import com.example.backend.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -12,5 +13,7 @@ import java.util.UUID;
 
 public interface BoardRepository extends JpaRepository<Board, UUID> {
     List<Board> findByBoardReportGreaterThanEqual(int boardReport);
+    
+    List<Board> findByUserId(User user);
 }
 

--- a/Back-end/src/main/java/com/example/backend/comment/repository/CommentRepository.java
+++ b/Back-end/src/main/java/com/example/backend/comment/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.example.backend.comment.repository;
 
 import com.example.backend.board.entity.Board;
 import com.example.backend.comment.entity.Comment;
+import com.example.backend.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,6 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
     Page<Comment> findByBoardId(Board board, Pageable pageable);
 
     List<Comment> findByCommentReportGreaterThanEqual(int i);
+    
+    List<Comment> findByUserId(User user);
 }

--- a/Back-end/src/main/java/com/example/backend/user/controller/UserController.java
+++ b/Back-end/src/main/java/com/example/backend/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.example.backend.user.dto.request.UserRequest.updateRequest;
 import com.example.backend.user.dto.response.UserResponse;
 import com.example.backend.user.dto.response.UserResponse.InformationResponse;
 import com.example.backend.user.dto.response.UserResponse.updateResponse;
+import com.example.backend.user.dto.response.UserResponse.deleteResponse;
 import com.example.backend.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -39,9 +40,9 @@ public class UserController {
 
     @DeleteMapping("/delete")
     @Operation(summary = "유저 삭제", description = "로컬 유저 탈퇴 API")
-    public ResponseEntity<Void> delete() {
-        userService.delete();
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<deleteResponse> delete() {
+        deleteResponse response = userService.delete();
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/me")

--- a/Back-end/src/main/java/com/example/backend/user/dto/response/UserResponse.java
+++ b/Back-end/src/main/java/com/example/backend/user/dto/response/UserResponse.java
@@ -50,4 +50,12 @@ public class UserResponse {
         @Schema(description = "프로필 이미지 URL", example = "https://example.com/images/profile/abcd.jpg")
         private String userProfileImage;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class deleteResponse {
+        @Schema(description = "회원 탈퇴 결과 메시지", example = "회원 탈퇴가 완료되었습니다.")
+        private String message;
+    }
 }


### PR DESCRIPTION
##개요

  - 사용자 삭제 시 관련 데이터 완전 삭제 로직 구현
  - 댓글, 게시글, 카트, 투어, 즐겨찾기 cascade 삭제 추가
  - 그룹 스케줄에서 사용자 제거 처리
  - 탈퇴 API 응답 형식을 void에서 deleteResponse로 변경
  - Repository에 사용자별 조회 메소드 추가
  - 탈퇴 과정 로깅 추가로 디버깅 편의성 향상



## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
